### PR TITLE
getstate should return a dictionary

### DIFF
--- a/paramz/optimization/optimization.py
+++ b/paramz/optimization/optimization.py
@@ -64,7 +64,7 @@ class Optimizer(object):
         return diagnostics
 
     def __getstate__(self):
-        return []
+        return {}
 
 
 class opt_tnc(Optimizer):

--- a/paramz/tests/parameterized_tests.py
+++ b/paramz/tests/parameterized_tests.py
@@ -135,7 +135,7 @@ class ModelTest(unittest.TestCase):
             self.testmodel.optimize_restarts(1, messages=1, optimizer=opt_tnc(), verbose=False)
             self.testmodel.optimize('tnc', messages=1, xtol=0, ftol=0, gtol=1e-6)
         np.testing.assert_array_less(self.testmodel.gradient, np.ones(self.testmodel.size)*1e-2)
-        self.assertListEqual(self.testmodel.optimization_runs[-1].__getstate__(), [])
+        self.assertDictEqual(self.testmodel.optimization_runs[-1].__getstate__(), {})
     def test_optimize_org_bfgs(self):
         import warnings
         with warnings.catch_warnings():


### PR DESCRIPTION
Pickle requires the **getstate**-function to return a dictionary (or maybe False?). The empty list results in an UnpicklingError. In the following example, `model` is a toy GPy-model which had one call to its `optimize`-method. This leads to a call of `GPy.load` failing with the same error which I followed to the optimizers.

> In [58]: o = model.optimization_runs[0]
> 
> In [59]: pickle.dumps(o)
> Out[59]: b'\x80\x03cparamz.optimization.optimization\nopt_SCG\nq\x00)\x81q\x01]q\x02b.'
> 
> In [60]: pickle.loads(pickle.dumps(o))
> UnpicklingError                           Traceback (most recent call last)
> <ipython-input-60-8199b6dff27d> in <module>()
> ----> 1 pickle.loads(pickle.dumps(o))
> 
> UnpicklingError: state is not a dictionary
