### PR TITLE
enforcing float dtype only for numeric inputs

### DIFF
--- a/paramz/core/observable_array.py
+++ b/paramz/core/observable_array.py
@@ -55,8 +55,12 @@ class ObsAr(np.ndarray, Pickleable, Observable):
     __array_priority__ = -1 # Never give back ObsAr
     def __new__(cls, input_array, *a, **kw):
         # allways make a copy of input paramters, as we need it to be in C order:
+        try:
+            dtype = np.array(input_array, dtype=np.float64).dtype
+        except ValueError:
+            dtype = input_array.dtype
         if not isinstance(input_array, ObsAr):
-            obj = np.atleast_1d(np.require(input_array, dtype=np.float64, requirements=['W', 'C'])).view(cls)
+            obj = np.atleast_1d(np.require(input_array, dtype=dtype, requirements=['W', 'C'])).view(cls)
         else: obj = input_array
         super(ObsAr, obj).__init__(*a, **kw)
         return obj


### PR DESCRIPTION
To be able to cope with inputs of any type, observable arrays should inherit the dtype from the input array instead of enforcing it to be a float.

However, while simple inheritance seems to work for paramz tests, it is breaking GPy because some arrays/values are integers and underlying Cython code expects floats. Ideally I think this issue should be addressed by GPy, not paramz. This might end up leading to a lot of change in the code.

I've come with kind of "compromise": if the input is numeric it forces it to be a float. It only inherits the type in case it fails to convert the input to a float. I am not entirely happy with this solution but it seems to be enough to allow arbitrary inputs like strings, etc.
