### PR TITLE
FIX: Prevent selecting optimizer dependcy on iteration order of dicti…

### DIFF
--- a/paramz/optimization/optimization.py
+++ b/paramz/optimization/optimization.py
@@ -324,7 +324,7 @@ def get_optimizer(f_min):
     #if rasm_available:
     #    optimizers['rasmussen'] = opt_rasm
 
-    for opt_name in optimizers.keys():
+    for opt_name in sorted(optimizers.keys()):
         if opt_name.lower().find(f_min.lower()) != -1:
             return optimizers[opt_name]
 


### PR DESCRIPTION
Previously, if the optimizer name was 'bfgs' then selected optimizer could be 'org-bfgs' or 'lbfgsb' depending on random order of dictionary keys iterator. Probably, it is possible to better handle optimizer selection e. g. warn about non-precise match of desired optimizer and existing optimizers. But this is a quick fix for unpredictable optimizer selection I encountered with.
