### PR TITLE
Fixed warning

### DIFF
--- a/paramz/model.py
+++ b/paramz/model.py
@@ -87,7 +87,7 @@ class Model(Parameterized):
             print("updates were off, setting updates on again")
             self.update_model(True)
 
-        if start == None:
+        if start is None:
             start = self.optimizer_array
 
         if optimizer is None:


### PR DESCRIPTION
There was a FutureWarning caused by the use of '=='. I fixed it by replacing with "is".
