### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,14 +31,14 @@ if on_rtd:
 
     proc = subprocess.Popen("pwd", stdout=subprocess.PIPE, shell=True)
     (out, err) = proc.communicate()
-    print "program output:", out
+    print("program output:", out)
     proc = subprocess.Popen("ls ../../", stdout=subprocess.PIPE, shell=True)
     (out, err) = proc.communicate()
-    print "program output:", out
+    print("program output:", out)
     #Lets regenerate our rst files from the source, -P adds private modules (i.e kern._src)
     proc = subprocess.Popen("sphinx-apidoc -P -f -o . ../../paramz", stdout=subprocess.PIPE, shell=True)
     (out, err) = proc.communicate()
-    print "program output:", out
+    print("program output:", out)
     #proc = subprocess.Popen("whereis numpy", stdout=subprocess.PIPE, shell=True)
     #(out, err) = proc.communicate()
     #print "program output:", out

--- a/paramz/caching.py
+++ b/paramz/caching.py
@@ -236,7 +236,7 @@ class Cacher(object):
         return self.operation.__name__
 
     def __str__(self, *args, **kwargs):
-        return "Cacher({})\n  limit={}\n  \#cached={}".format(self.__name__, self.limit, len(self.cached_input_ids))
+        return "Cacher({})\n  limit={}\n  \\#cached={}".format(self.__name__, self.limit, len(self.cached_input_ids))
 
 class FunctionCache(dict):
     def __init__(self, *args, **kwargs):

--- a/paramz/core/parameter_core.py
+++ b/paramz/core/parameter_core.py
@@ -299,7 +299,7 @@ class OptimizationHandlable(Constrainable):
         pass
 
 
-_name_digit = re.compile("(?P<name>.*)_(?P<digit>\d+)$")
+_name_digit = re.compile(r"(?P<name>.*)_(?P<digit>\d+)$")
 class Parameterizable(OptimizationHandlable):
     """
     A parameterisable class.

--- a/paramz/model.py
+++ b/paramz/model.py
@@ -116,7 +116,7 @@ class Model(Parameterized):
         return opt
 
     def optimize_restarts(self, num_restarts=10, robust=False, verbose=True, parallel=False, num_processes=None, **kwargs):
-        """
+        r"""
         Perform random restarts of the model, and set the model to the best
         seen solution.
 

--- a/paramz/transformations.py
+++ b/paramz/transformations.py
@@ -81,7 +81,7 @@ class Transformation(object):
 
         .. math::
 
-            \frac{\frac{\partial L}{\partial f}\left(\left.\partial f(x)}{\partial x}\right|_{x=f^{-1}(f)\right)}
+            \frac{\frac{\\partial L}{\\partial f}\\left(\\left.\\partial f(x)}{\\partial x}\right|_{x=f^{-1}(f)\right)}
         """
         raise NotImplementedError
     def gradfactor_non_natural(self, model_param, dL_dmodel_param):


### PR DESCRIPTION
When trying to use paramz from GPy with Python 3.12, I get Syntax Errors and Warnings related to Invalid Escape Sequences.
This should fix these problems by either adding more slashes, or using r-Strings.